### PR TITLE
Calendar widgets not showing in block editor

### DIFF
--- a/includes/widgets/calendar.php
+++ b/includes/widgets/calendar.php
@@ -125,7 +125,7 @@ class Calendar extends \WP_Widget implements Widget {
 		$title          = isset( $instance['title'] )       ? esc_attr( $instance['title'] ) : __( 'Calendar', 'google-calendar-events' );
 		$calendar_id    = isset( $instance['calendar_id'] ) ? esc_attr( $instance['calendar_id'] ) : '';
 
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+		if ( empty($this->calendars)  && defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 			$this->calendars = simcal_get_calendars();
 		}
 		?>

--- a/includes/widgets/calendar.php
+++ b/includes/widgets/calendar.php
@@ -53,7 +53,7 @@ class Calendar extends \WP_Widget implements Widget {
 
 		parent::__construct( $id_base, $name, $widget_options );
 
-		if ( is_admin() ) {
+		if ( WP_ADMIN  ) {
 			if ( ! defined( 'DOING_AJAX' ) ) {
 				$this->calendars = simcal_get_calendars();
 			} else {

--- a/includes/widgets/calendar.php
+++ b/includes/widgets/calendar.php
@@ -53,14 +53,12 @@ class Calendar extends \WP_Widget implements Widget {
 
 		parent::__construct( $id_base, $name, $widget_options );
 
-		if ( is_admin() ) {
+		if ( WP_ADMIN  ) {
 			if ( ! defined( 'DOING_AJAX' ) ) {
 				$this->calendars = simcal_get_calendars();
 			} else {
 				$this->calendars = get_transient( '_simple-calendar_feed_ids' );
 			}
-		}else{
-			$this->calendars = simcal_get_calendars();
 		}
 	}
 
@@ -139,11 +137,7 @@ class Calendar extends \WP_Widget implements Widget {
 				       class="widefat simcal-field simcal-field-standard simcal-field-text"
 				       value="<?php echo $title; ?>">
 			</p>
-<?php if(is_admin())
-    {
-		echo "afafaf";
-		print_r($this->calendars);
-	} ?>
+
 			<p>
 				<label for="<?php echo $this->get_field_id( 'calendar_id' ); ?>"><?php _e( 'Calendar:', 'google-calendar-events' ); ?></label>
 				<br>
@@ -152,7 +146,7 @@ class Calendar extends \WP_Widget implements Widget {
 				        id="<?php echo $this->get_field_id( 'calendar_id' ) ?>"
 						class="simcal-field simcal-field-select<?php echo $multiselect; ?>"
 						data-noresults="<?php __( 'No calendars found.', 'google-calendar-events' ); ?>">
-						<?php  foreach ( $this->calendars as $id => $name ) : ?>
+						<?php foreach ( $this->calendars as $id => $name ) : ?>
 							<option value="<?php echo $id; ?>" <?php selected( $id, $calendar_id, true ); ?>><?php echo $name; ?></option>
 						<?php endforeach; ?>
 				</select>

--- a/includes/widgets/calendar.php
+++ b/includes/widgets/calendar.php
@@ -53,7 +53,7 @@ class Calendar extends \WP_Widget implements Widget {
 
 		parent::__construct( $id_base, $name, $widget_options );
 
-		if ( WP_ADMIN  ) {
+		if ( is_admin() ) {
 			if ( ! defined( 'DOING_AJAX' ) ) {
 				$this->calendars = simcal_get_calendars();
 			} else {
@@ -137,7 +137,11 @@ class Calendar extends \WP_Widget implements Widget {
 				       class="widefat simcal-field simcal-field-standard simcal-field-text"
 				       value="<?php echo $title; ?>">
 			</p>
-
+				<?php 
+				if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+					$this->calendars = simcal_get_calendars();
+				}
+			?>
 			<p>
 				<label for="<?php echo $this->get_field_id( 'calendar_id' ); ?>"><?php _e( 'Calendar:', 'google-calendar-events' ); ?></label>
 				<br>

--- a/includes/widgets/calendar.php
+++ b/includes/widgets/calendar.php
@@ -53,12 +53,14 @@ class Calendar extends \WP_Widget implements Widget {
 
 		parent::__construct( $id_base, $name, $widget_options );
 
-		if ( WP_ADMIN  ) {
+		if ( is_admin() ) {
 			if ( ! defined( 'DOING_AJAX' ) ) {
 				$this->calendars = simcal_get_calendars();
 			} else {
 				$this->calendars = get_transient( '_simple-calendar_feed_ids' );
 			}
+		}else{
+			$this->calendars = simcal_get_calendars();
 		}
 	}
 
@@ -137,7 +139,11 @@ class Calendar extends \WP_Widget implements Widget {
 				       class="widefat simcal-field simcal-field-standard simcal-field-text"
 				       value="<?php echo $title; ?>">
 			</p>
-
+<?php if(is_admin())
+    {
+		echo "afafaf";
+		print_r($this->calendars);
+	} ?>
 			<p>
 				<label for="<?php echo $this->get_field_id( 'calendar_id' ); ?>"><?php _e( 'Calendar:', 'google-calendar-events' ); ?></label>
 				<br>
@@ -146,7 +152,7 @@ class Calendar extends \WP_Widget implements Widget {
 				        id="<?php echo $this->get_field_id( 'calendar_id' ) ?>"
 						class="simcal-field simcal-field-select<?php echo $multiselect; ?>"
 						data-noresults="<?php __( 'No calendars found.', 'google-calendar-events' ); ?>">
-						<?php foreach ( $this->calendars as $id => $name ) : ?>
+						<?php  foreach ( $this->calendars as $id => $name ) : ?>
 							<option value="<?php echo $id; ?>" <?php selected( $id, $calendar_id, true ); ?>><?php echo $name; ?></option>
 						<?php endforeach; ?>
 				</select>

--- a/includes/widgets/calendar.php
+++ b/includes/widgets/calendar.php
@@ -125,6 +125,9 @@ class Calendar extends \WP_Widget implements Widget {
 		$title          = isset( $instance['title'] )       ? esc_attr( $instance['title'] ) : __( 'Calendar', 'google-calendar-events' );
 		$calendar_id    = isset( $instance['calendar_id'] ) ? esc_attr( $instance['calendar_id'] ) : '';
 
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			$this->calendars = simcal_get_calendars();
+		}
 		?>
 		<div class="simcal-calendar-widget-settings">
 
@@ -137,11 +140,7 @@ class Calendar extends \WP_Widget implements Widget {
 				       class="widefat simcal-field simcal-field-standard simcal-field-text"
 				       value="<?php echo $title; ?>">
 			</p>
-				<?php 
-				if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-					$this->calendars = simcal_get_calendars();
-				}
-			?>
+
 			<p>
 				<label for="<?php echo $this->get_field_id( 'calendar_id' ); ?>"><?php _e( 'Calendar:', 'google-calendar-events' ); ?></label>
 				<br>


### PR DESCRIPTION
Description: Calendar are not display in block editor because of the is_admin condition and in block editor it is actually show preview so it is front end technically.  If you have a server side rendered block in the backend, it is rendered via the REST API endpoint /wp/v2/block-renderer/xyz/blockname. This endpoint calls your render function. In the frontend the render function is called directly. The function is_admin() checks if a backend page was requested. In a REST API Request is no backend page, so the function returns false on REST API requests. 
**Refrence**: https://wordpress.stackexchange.com/questions/343583/is-admin-returning-false-in-backend-in-server-side-rendered-block/343592#343592
Task: https://github.com/orgs/Xtendify/projects/2?pane=issue&itemId=23991748

