### PR TITLE
oob auth code expire issue

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -528,3 +528,18 @@
 		});
 	});
 })(this);
+
+//* The below is run after the DOM has fully loaded */
+(function (window, undefined) {
+	'use strict';
+
+	function onLoadHandler() {
+		var currentUrl = window.location.href;
+		if (currentUrl.includes('code=')) {
+			/* Remove all parameters after 'code' */
+			var newUrl = currentUrl.replace(/([?&])code=[^&]+(.*)$/, '$1');
+			window.history.replaceState({}, document.title, newUrl);
+		}
+	}
+	window.onload = onLoadHandler;
+})(window);


### PR DESCRIPTION
**Description:** Due to Google policy update we can use the OOB redirect url So I update the authentication process user now no need to copy past their auth code it will auto save in the field.

**Trello** https://trello.com/c/A51t1RNN
**After: ** https://www.screenpresso.com/=Yqcad