### PR TITLE
Date format issue on narrow width

### DIFF
--- a/includes/calendars/views/default-calendar-list.php
+++ b/includes/calendars/views/default-calendar-list.php
@@ -432,16 +432,36 @@ class Default_Calendar_List implements Calendar_View
 			$large = $small = date_i18n($calendar->date_format, $st);
 			if ($date_order['d'] !== false && $date_order['m'] !== false) {
 				if ($date_order['m'] > $date_order['d']) {
-					if ($date_order['y'] !== false && $date_order['y'] > $date_order['m']) {
-						$small = date_i18n('Y, d M', $st);
+					if (
+						$date_order['y'] !== false &&
+						$date_order['y'] > $date_order['m'] &&
+						$date_order['m'] > $date_order['d']
+					) {
+						if ($date_order['y'] > $date_order['m'] && $date_order['m'] > $date_order['d']) {
+							$small = date_i18n('d/m/Y', $st);
+						} else {
+							$small = date_i18n('Y, d M', $st);
+						}
+					} elseif ($date_order['m'] > $date_order['y'] && $date_order['m'] > $date_order['d']) {
+						$small = date_i18n('Y, m d', $st);
+					} elseif ($date_order['y'] > $date_order['m'] && $date_order['d'] > $date_order['m']) {
+						$small = date_i18n('d m Y', $st);
 					} else {
 						$small = date_i18n('d M Y', $st);
 					}
 				} else {
 					if ($date_order['y'] !== false && $date_order['y'] > $date_order['m']) {
-						$small = date_i18n('Y, M d', $st);
+						if ($date_order['d'] > $date_order['m']) {
+							$small = date_i18n('M d Y', $st);
+						} else {
+							$small = date_i18n('Y, M d', $st);
+						}
 					} else {
-						$small = date_i18n('M d Y', $st);
+						if ($date_order['d'] > $date_order['m']) {
+							$small = date_i18n('Y-m-d', $st);
+						} else {
+							$small = date_i18n('M d Y', $st);
+						}
 					}
 				}
 			}

--- a/includes/functions/shared.php
+++ b/includes/functions/shared.php
@@ -311,7 +311,7 @@ function simcal_default_event_template()
  */
 function simcal_get_date_format_order($date_format)
 {
-	$d = strpbrk($date_format, 'Dj');
+	$d = strpbrk($date_format, 'Djd');
 	$m = strpbrk($date_format, 'FMmn');
 	$y = strpbrk($date_format, 'Yy');
 


### PR DESCRIPTION
**Description:**  There seems to be a date formatting issue in List type calendars once the calendar Shortcode is added to a page on a section with a narrow column. or on a mobile screen.
**Description Video:** https://www.screenpresso.com/=yGNpc
**Trello:** https://trello.com/c/t5sxpPoi

**QA steps:** https://www.screenpresso.com/=o1bmg