### PR TITLE
Fix event rendering

### DIFF
--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -12,6 +12,8 @@ use SimpleCalendar\Abstracts\Calendar;
 use SimpleCalendar\Abstracts\Calendar_View;
 use SimpleCalendar\Events\Event;
 use SimpleCalendar\Calendars\Default_Calendar;
+use \DateTime;
+use \DateTimeZone;
 
 if (!defined('ABSPATH')) {
 	exit();
@@ -165,6 +167,20 @@ class Default_Calendar_Grid implements Calendar_View
 	}
 
 	/**
+	 * Format the timestamp with timeZone to display exact month as per the diffrent timezone.
+	 *
+	 * @since  3.4.1
+	 */
+	public function format_timestamp($dateformat = 'F', $timestamp)
+	{
+		$datetime = new \DateTime();
+		$datetime->setTimezone(new \DateTimeZone($this->calendar->timezone));
+		$datetime->setTimestamp($timestamp);
+		$formatted_date = $datetime->format($dateformat);
+
+		return $formatted_date;
+	}
+	/**
 	 * Default calendar grid markup.
 	 *
 	 * @since  3.0.0
@@ -215,7 +231,7 @@ class Default_Calendar_Grid implements Calendar_View
       }
 
       foreach ($current as $k => $v) {
-      	echo ' <span class="simcal-current-' . $k, '">' . date_i18n($v, $calendar->start) . '</span> ';
+      	echo ' <span class="simcal-current-' . $k, '">' . $this->format_timestamp($v, $calendar->start) . '</span> ';
       }
 
       echo '</h3>';
@@ -264,7 +280,10 @@ class Default_Calendar_Grid implements Calendar_View
                 </tr>
                 </thead>
 
-				<?php echo $this->draw_month(date('n', $calendar->start), date('Y', $calendar->start)); ?>	 			
+				<?php echo $this->draw_month(
+    	date($this->format_timestamp('n', $calendar->start)),
+    	date($this->format_timestamp('Y', $calendar->start))
+    ); ?>	 			
             </table>
 
 			<?php

--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -500,6 +500,7 @@ class Google extends Feed
 	 */
 	public function make_request($id = '', $time_min = 0, $time_max = 0)
 	{
+		$post_id = get_the_ID();
 		$calendar = [];
 		$google = $this->get_service();
 
@@ -556,10 +557,12 @@ class Google extends Feed
 			}
 
 			$is_authhelper = get_option('simple_calendar_run_oauth_helper');
+			$feed_type = wp_get_object_terms( $post_id, 'calendar_feed' );
+
 			// Query events in calendar.
 			$simple_calendar_auth_site_token = get_option('simple_calendar_auth_site_token');
 			$response = '';
-			if (isset($simple_calendar_auth_site_token) && !empty($simple_calendar_auth_site_token && $is_authhelper)) {
+			if (isset($simple_calendar_auth_site_token) && !empty($simple_calendar_auth_site_token && $is_authhelper) && $feed_type[0]->slug != 'google') {
 				$response = apply_filters('simple_calendar_oauth_list_events', '', $id, $args);
 
 				if (isset($response['Error']) && !empty($response['Error'])) {

--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -557,12 +557,16 @@ class Google extends Feed
 			}
 
 			$is_authhelper = get_option('simple_calendar_run_oauth_helper');
-			$feed_type = wp_get_object_terms( $post_id, 'calendar_feed' );
+			$feed_type = wp_get_object_terms($post_id, 'calendar_feed');
 
 			// Query events in calendar.
 			$simple_calendar_auth_site_token = get_option('simple_calendar_auth_site_token');
 			$response = '';
-			if (isset($simple_calendar_auth_site_token) && !empty($simple_calendar_auth_site_token && $is_authhelper) && $feed_type[0]->slug != 'google') {
+			if (
+				isset($simple_calendar_auth_site_token) &&
+				!empty($simple_calendar_auth_site_token && $is_authhelper) &&
+				$feed_type[0]->slug != 'google'
+			) {
 				$response = apply_filters('simple_calendar_oauth_list_events', '', $id, $args);
 
 				if (isset($response['Error']) && !empty($response['Error'])) {

--- a/includes/main.php
+++ b/includes/main.php
@@ -118,7 +118,7 @@ final class Plugin
 		add_action('admin_init', [$this, 'register_settings'], 5);
 
 		//Oauth Helper init
-		add_action('admin_init', [$this, 'oauth_helper_init'], 5);
+		add_action('init', [$this, 'oauth_helper_init'], 5);
 
 		// Upon plugin loaded action hook.
 		do_action('simcal_loaded');

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.4.2",
+  "version": "3.4.3",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.4.3 =
+* Fix: Calendar Start Date Issue in Grid View.
+
 = 3.4.2 =
 * Fix: Event rendering issue for public calendar while using Auth via Xtendify.
 

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.4.2 =
+* Fix: Event rendering issue.
+
 = 3.4.1 =
 * Dev: Add OAuth helper functionality.
 * Dev: Make OAuth helper option compatibble with Appointment add-on.

--- a/readme.txt
+++ b/readme.txt
@@ -98,7 +98,7 @@ We'd love your help! Here's a few things you can do:
 == Changelog ==
 
 = 3.4.2 =
-* Fix: Event rendering issue.
+* Fix: Event rendering issue for public calendar while using Auth via Xtendify.
 
 = 3.4.1 =
 * Dev: Add OAuth helper functionality.


### PR DESCRIPTION
**Description:** Due to some conflict events are not rendered if user use the Xtendify auth and want to display event from public calendar.
**clickup**: https://app.clickup.com/t/86cw85zyf
**Before**: https://www.screenpresso.com/cloud/EuS7c/
**After**: https://www.screenpresso.com/=L4U6c