### PR TITLE
double event issue

### DIFF
--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -367,19 +367,10 @@ class Default_Calendar_Grid implements Calendar_View
 			$current_month = Carbon::createFromTimestamp($this->start, $calendar->timezone)->month;
 			$current_year = Carbon::createFromTimestamp($this->start, $calendar->timezone)->year;
 
-			$filtered = array_filter($events, function ($events_in_day) {
-				foreach ($events_in_day as $event) {
-					if ($event instanceof Event) {
-						if (
-							($event->start >= $this->start && $event->start < $this->end + 86400) ||
-							($event->end >= $this->start && $event->end < $this->end + 86400)
-						) {
-							return true;
-						}
-					}
-				}
-				return false;
-			});
+			$filtered =
+				is_array($events) && is_array($higher_bound) && !empty($events) && !empty($higher_bound)
+					? array_intersect_key($events, array_combine($higher_bound, $higher_bound))
+					: [];
 
 			$day_events = [];
 			foreach ($filtered as $timestamp => $events_in_day) {

--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -171,7 +171,7 @@ class Default_Calendar_Grid implements Calendar_View
 	 *
 	 * @since  3.4.3
 	 */
-	public function format_timestamp($format = 'F', $timestamp)
+	public function format_timestamp($timestamp, $format = 'F')
 	{
 		$datetime = new \DateTime();
 		$datetime->setTimezone(new \DateTimeZone($this->calendar->timezone));
@@ -231,7 +231,7 @@ class Default_Calendar_Grid implements Calendar_View
       }
 
       foreach ($current as $k => $v) {
-      	echo ' <span class="simcal-current-' . $k, '">' . $this->format_timestamp($v, $calendar->start) . '</span> ';
+      	echo ' <span class="simcal-current-' . $k, '">' . $this->format_timestamp($calendar->start, $v) . '</span> ';
       }
 
       echo '</h3>';
@@ -281,8 +281,8 @@ class Default_Calendar_Grid implements Calendar_View
                 </thead>
 
 				<?php echo $this->draw_month(
-    	date($this->format_timestamp('n', $calendar->start)),
-    	date($this->format_timestamp('Y', $calendar->start))
+    	date($this->format_timestamp($calendar->start, 'n')),
+    	date($this->format_timestamp($calendar->start, 'Y'))
     ); ?>	 			
             </table>
 

--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -383,7 +383,9 @@ class Default_Calendar_Grid implements Calendar_View
 							if ($day->month == $current_month && $day->year == $current_year) {
 								$day_key = intval($day->format('j'));
 								$event_id = $event->uid;
-
+								/*
+								 * The purpose of this condition is to determine if an event ends at the very start of the day.
+								 */
 								if ($day->isSameDay($event_end) && $event_end->hour == 0 && $event_end->minute == 0) {
 									continue;
 								}

--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -562,13 +562,13 @@ class Google extends Feed
 			// Query events in calendar.
 			$simple_calendar_auth_site_token = get_option('simple_calendar_auth_site_token');
 			$response = '';
+			$backgroundcolor = '';
 			if (
 				isset($simple_calendar_auth_site_token) &&
 				!empty($simple_calendar_auth_site_token && $is_authhelper) &&
 				isset($feed_type[0]->slug) &&
 				$feed_type[0]->slug != 'google'
 			) {
-				$backgroundcolor = '';
 				$response_arr = apply_filters('simple_calendar_oauth_list_events', '', $id, $args);
 
 				$response = unserialize($response_arr['data']);

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,11 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.4.4 =
+* Fix: Fixed deprecation notices and warnings to ensure compatibility with the latest WordPress updates.
+* Fix: Resolved an issue where multi-day events were being rendered as double events on the same day.
+* Fix: De Authentication issue fix. 
+
 = 3.4.3 =
 * Fix: Event color not showing in Calendar when using OAuth via Xtendify.
 * Fix: Date format inconsistencies when using shortcodes in certain conditions.


### PR DESCRIPTION
**Description:** There was an issue in which if the event  is set for full day and more then one day then it will duplicate the event first day Also, in my testing, I have found that the event is not displayed on months last day so I have updated the event filter code and add some condition that prevent from duplicate event on the day.
**After:** https://www.screenpresso.com/=pPD51FQi7X9e
**clickup:** https://app.clickup.com/t/86cwkpk16
issue: https://wordpress.org/support/topic/all-day-events-are-duplicated-on-the-calendar/
https://wordpress.org/support/topic/deprecated-warning-25/
https://github.com/Xtendify/Simple-Calendar/issues/575