### PR TITLE
De Authentication issue fix

### DIFF
--- a/includes/oauthhelper/oauth-service-actions.php
+++ b/includes/oauthhelper/oauth-service-actions.php
@@ -81,13 +81,13 @@ class Oauth_Ajax
 		$response_arr = json_decode($response, true);
 
 		$error_msg = [];
+		delete_option('simple_calendar_auth_site_token');
+		
 		if ($response_arr['response']) {
-			delete_option('simple_calendar_auth_site_token');
 			$message = __('DeAuthenticate Successfully.', 'google-calendar-events');
 			$send_msg = ['message' => $message];
 			wp_send_json_success($send_msg);
-		} else {
-			delete_option('simple_calendar_auth_site_token');
+		} else {		
 			if (isset($message['message']) && !empty($message['message'])) {
 				$message = $message['message'];
 			} else {

--- a/includes/oauthhelper/oauth-service-actions.php
+++ b/includes/oauthhelper/oauth-service-actions.php
@@ -87,6 +87,7 @@ class Oauth_Ajax
 			$send_msg = ['message' => $message];
 			wp_send_json_success($send_msg);
 		} else {
+			delete_option('simple_calendar_auth_site_token');
 			if (isset($message['message']) && !empty($message['message'])) {
 				$message = $message['message'];
 			} else {

--- a/includes/oauthhelper/oauth-service-actions.php
+++ b/includes/oauthhelper/oauth-service-actions.php
@@ -82,12 +82,12 @@ class Oauth_Ajax
 
 		$error_msg = [];
 		delete_option('simple_calendar_auth_site_token');
-		
+
 		if ($response_arr['response']) {
 			$message = __('DeAuthenticate Successfully.', 'google-calendar-events');
 			$send_msg = ['message' => $message];
 			wp_send_json_success($send_msg);
-		} else {		
+		} else {
 			if (isset($message['message']) && !empty($message['message'])) {
 				$message = $message['message'];
 			} else {


### PR DESCRIPTION
**Description:** we were only remove this option when user's site data are deleted successfully from auth site.
Following this update, if the user de-authenticates, this option will be removed from their website and they will be able to authenticate again. Data deletion from the authentication website is not compulsory now.
**After:** https://www.screenpresso.com/=70MSwUdmw2CT
**Clickup:** https://app.clickup.com/t/86cwnft31
