### PR TITLE
Update google.php - Fix PHP 8 commit

### DIFF
--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -191,9 +191,9 @@ class Google extends Feed
 							}
 
 							// Event title & description.
-							$title = strip_tags($event->getSummary() || '');
+							$title = strip_tags($event->getSummary());
 							$title = sanitize_text_field(iconv(mb_detect_encoding($title, mb_detect_order(), true), 'UTF-8', $title));
-							$description = $event->getDescription() || '';
+							$description = $event->getDescription();
 							$description = wp_kses_post(
 								iconv(mb_detect_encoding($description, mb_detect_order(), true), 'UTF-8', $description)
 							);


### PR DESCRIPTION
Breaks output down to "1" in frontend at least when running on PHP 7.4 which is currently least full supported PHP of wordpress.