### PR TITLE
Translation month name on load

### DIFF
--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -231,7 +231,7 @@ class Default_Calendar_Grid implements Calendar_View
       }
 
       foreach ($current as $k => $v) {
-      	echo ' <span class="simcal-current-' . $k, '">' . $this->format_timestamp($calendar->start, $v) . '</span> ';
+      	echo ' <span class="simcal-current-' . $k, '">' .wp_date($v, $calendar->start)  . '</span> ';
       }
 
       echo '</h3>';


### PR DESCRIPTION
**Description:** If the site is set to a different language other than English and the calendar id previewed on the front-end, the first month seems to be rendered in English instead of the set site language. Upon navigating to the other months, the correct language is applied to the months.
**Sol:** I have added a wordpress time function which returns the tranlated mont name.
**Clickup:** https://app.clickup.com/t/86cwp5p0x
**Before:** https://www.screenpresso.com/cloud/Ml6xEsu5EmYz/
**After:** https://www.screenpresso.com/=X2NwHpG4J9jb