### PR TITLE
fixed calIendar ID issue when using shortcode

### DIFF
--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -153,12 +153,12 @@ class Google extends Feed
 	 * @return string|array
 	 */
 	public function get_events()
-	{ 		
+	{
 		$calendar = get_transient('_simple-calendar_feed_id_' . strval($this->post_id) . '_' . $this->type);
 
 		if (empty($calendar) && !empty($this->google_calendar_id)) {
 			$error = '';
-			
+
 			try {
 				$response = $this->make_request($this->google_calendar_id);
 			} catch (Google_Service_Exception $e) {
@@ -500,7 +500,7 @@ class Google extends Feed
 	 * @throws Exception On request failure will throw an exception from Google.
 	 */
 	public function make_request($id = '', $time_min = 0, $time_max = 0)
-	{ 
+	{
 		$calendar = [];
 		$google = $this->get_service();
 
@@ -561,14 +561,14 @@ class Google extends Feed
 
 			// Query events in calendar.
 			$simple_calendar_auth_site_token = get_option('simple_calendar_auth_site_token');
-			$response = ''; 
+			$response = '';
 			$backgroundcolor = '';
 			if (
 				isset($simple_calendar_auth_site_token) &&
 				!empty($simple_calendar_auth_site_token && $is_authhelper) &&
 				isset($feed_type[0]->slug) &&
 				$feed_type[0]->slug != 'google'
-			) { 
+			) {
 				$response_arr = apply_filters('simple_calendar_oauth_list_events', '', $id, $args);
 
 				$response = unserialize($response_arr['data']);
@@ -579,7 +579,7 @@ class Google extends Feed
 				if (isset($response['Error']) && !empty($response['Error'])) {
 					throw new Google_Service_Exception($response['Error'], 1);
 				}
-			} else { 
+			} else {
 				$response = $google->events->listEvents($id, $args);
 			}
 

--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -153,12 +153,12 @@ class Google extends Feed
 	 * @return string|array
 	 */
 	public function get_events()
-	{
+	{ 		
 		$calendar = get_transient('_simple-calendar_feed_id_' . strval($this->post_id) . '_' . $this->type);
 
 		if (empty($calendar) && !empty($this->google_calendar_id)) {
 			$error = '';
-
+			
 			try {
 				$response = $this->make_request($this->google_calendar_id);
 			} catch (Google_Service_Exception $e) {
@@ -500,8 +500,7 @@ class Google extends Feed
 	 * @throws Exception On request failure will throw an exception from Google.
 	 */
 	public function make_request($id = '', $time_min = 0, $time_max = 0)
-	{
-		$post_id = get_the_ID();
+	{ 
 		$calendar = [];
 		$google = $this->get_service();
 
@@ -558,18 +557,18 @@ class Google extends Feed
 			}
 
 			$is_authhelper = get_option('simple_calendar_run_oauth_helper');
-			$feed_type = wp_get_object_terms($post_id, 'calendar_feed');
+			$feed_type = wp_get_object_terms($this->post_id, 'calendar_feed');
 
 			// Query events in calendar.
 			$simple_calendar_auth_site_token = get_option('simple_calendar_auth_site_token');
-			$response = '';
+			$response = ''; 
 			$backgroundcolor = '';
 			if (
 				isset($simple_calendar_auth_site_token) &&
 				!empty($simple_calendar_auth_site_token && $is_authhelper) &&
 				isset($feed_type[0]->slug) &&
 				$feed_type[0]->slug != 'google'
-			) {
+			) { 
 				$response_arr = apply_filters('simple_calendar_oauth_list_events', '', $id, $args);
 
 				$response = unserialize($response_arr['data']);
@@ -580,7 +579,7 @@ class Google extends Feed
 				if (isset($response['Error']) && !empty($response['Error'])) {
 					throw new Google_Service_Exception($response['Error'], 1);
 				}
-			} else {
+			} else { 
 				$response = $google->events->listEvents($id, $args);
 			}
 

--- a/includes/oauthhelper/oauth-service-actions.php
+++ b/includes/oauthhelper/oauth-service-actions.php
@@ -81,9 +81,9 @@ class Oauth_Ajax
 		$response_arr = json_decode($response, true);
 
 		$error_msg = [];
-		$message ='';
+		$message = '';
 		delete_option('simple_calendar_auth_site_token');
-		
+
 		if ($response_arr['response']) {
 			$message = __('DeAuthenticate Successfully.', 'google-calendar-events');
 			$send_msg = ['message' => $message];

--- a/includes/oauthhelper/oauth-service-actions.php
+++ b/includes/oauthhelper/oauth-service-actions.php
@@ -81,8 +81,9 @@ class Oauth_Ajax
 		$response_arr = json_decode($response, true);
 
 		$error_msg = [];
+		$message ='';
 		delete_option('simple_calendar_auth_site_token');
-
+		
 		if ($response_arr['response']) {
 			$message = __('DeAuthenticate Successfully.', 'google-calendar-events');
 			$send_msg = ['message' => $message];

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.5.1 =
+* Fix: Event were not showing on page with shortcode when using OAuth via Xtendify.
+
 = 3.5.0 =
 * Dev: To make the first attachment appear as the cover, add a new shortcode [cover-image] for GCal-Pro Addon.
 


### PR DESCRIPTION
**Description: **When using a shortcode, there were problems obtaining the calendar ID; this took the page ID and caused problems. I resolved the issue by using $this to obtain the calendar ID.
**clickup:** https://app.clickup.com/t/86cxe5vc0
**QA & before/after:** https://www.screenpresso.com/=tx6VYGCIojOv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where events were not displaying on pages using shortcodes when OAuth authentication was enabled via Xtendify.

- **Documentation**
  - Updated the changelog to include details for version 3.5.1.

- **Chores**
  - Incremented the version number to 3.5.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->