### PR TITLE
version update in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {


### PR DESCRIPTION
**Description:** In the [PR216](https://github.com/Xtendify/Simple-Calendar/pull/612) I have added an admin notice and update the changelog, but after review and QA I forgot to update the version in the package file. Due to this, the plugin version is not updated in the main file. To upgrade the plugin version, I have created this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the application version number to 3.5.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->