### PR TITLE
Fix PHP version comparison logic in admin notice function

### DIFF
--- a/includes/functions/admin.php
+++ b/includes/functions/admin.php
@@ -439,7 +439,7 @@ function simcal_notice_to_update_php_version()
 	$notice_id = 'simcal_check_site_php_version';
 	$requirements = 8.0;
 
-	if (version_compare(PHP_VERSION, $requirements === -1)) {
+	if (version_compare(PHP_VERSION, $requirements) === -1) {
 		$update_pro_notice = new Notice([
 			'id' => [
 				$notice_id => 'check_site_php_version',


### PR DESCRIPTION
![Screenshot 2025-05-13 094823](https://github.com/user-attachments/assets/a8feabd2-91e4-4525-bec3-269f19f9e0fc)

## Problem
The Image above shows that my current version of PHP was higher than the required version that was recommended by the plugin. 

My server PHP version was up to date. 

I checked to see the recent changes made the plugin and found the logic comparison was correct, but one parenthesis was place in the wrong position. 

## Local Changes
 
By moving parenthesis over to the left the logic can compare the $requirements variable and the users current PHP Version to see if it returns a value of 0 if current version if higher than '$requirement' or -1 if current version is lower than '$requirement'.

I checked on my development site to see if the issue will occur with my small change and the Notice banner is now behaving correctly. 

I also did a local test by changing the '$requirements' variable to a higher version of my current version to simulate a false reading. As intended the Notice banner appeared to show that the logic is returning a '-1'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the logic for checking PHP version requirements, ensuring users are properly notified if their PHP version is below the required version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->