### PR TITLE
fix notice show for php8

### DIFF
--- a/includes/functions/admin.php
+++ b/includes/functions/admin.php
@@ -439,7 +439,7 @@ function simcal_notice_to_update_php_version()
 	$notice_id = 'simcal_check_site_php_version';
 	$requirements = 8.0;
 
-	if (version_compare(PHP_VERSION, $requirements === -1)) {
+	if (version_compare(PHP_VERSION, $requirements, '<')) {
 		$update_pro_notice = new Notice([
 			'id' => [
 				$notice_id => 'check_site_php_version',

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.5.2",
+  "version": "3.5.3",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.5.3 =
+* Fix: Even after upgrading to PHP 8.x, an admin notice still appears to upgrade to PHP8.
+
 = 3.5.2 =
 * Dev: Make compatible with WordPress v6.8.1.
 * Dev: Added notice to update PHP version if version is less then 8.1.


### PR DESCRIPTION
**Description:** The notice to upgrade the php version is shown event after the PHP is upgrade to 8.x is fixed now.
**before & After:** https://www.screenpresso.com/=r7o3UJlcgCz4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the admin notice prompting users to upgrade to PHP 8 would still appear even after upgrading to PHP 8.x.

- **Documentation**
  - Updated the changelog to reflect the bug fix in version 3.5.3.

- **Chores**
  - Bumped the version number to 3.5.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->