### PR TITLE
Multiday event expand issue fix

### DIFF
--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -373,13 +373,15 @@ class Default_Calendar_Grid implements Calendar_View
 					: [];
 
 			$day_events = [];
-			if ('yes' == get_post_meta($calendar->id, '_default_calendar_expand_multi_day_events', true)) {
-				foreach ($filtered as $timestamp => $events_in_day) {
-					foreach ($events_in_day as $event) {
-						if ($event instanceof Event) {
-							$event_start = Carbon::createFromTimestamp($event->start, $calendar->timezone);
-							$event_end = Carbon::createFromTimestamp($event->end, $calendar->timezone);
 
+			foreach ($filtered as $timestamp => $events_in_day) {
+				foreach ($events_in_day as $event) {
+					if ($event instanceof Event) {
+						$event_start = Carbon::createFromTimestamp($event->start, $calendar->timezone);
+						$event_end = Carbon::createFromTimestamp($event->end, $calendar->timezone);
+						$first_day = intval(Carbon::createFromTimestamp($timestamp, $calendar->timezone)->endOfDay()->day);
+
+						if ('yes' == get_post_meta($calendar->id, '_default_calendar_expand_multi_day_events', true)) {
 							for ($day = $event_start->copy(); $day->lte($event_end->endOfDay()); $day->addDay()) {
 								if ($day->month == $current_month && $day->year == $current_year) {
 									$day_key = intval($day->format('j'));
@@ -396,22 +398,15 @@ class Default_Calendar_Grid implements Calendar_View
 									}
 								}
 							}
+						} else {
+							$day_events[$first_day][] = $event;
 						}
 					}
 				}
+			}
 
-				foreach ($day_events as $day_key => $events) {
-					$day_events[$day_key] = array_values($events);
-				}
-			} else {
-				foreach ($filtered as $timestamp => $events_in_day) {
-					foreach ($events_in_day as $event) {
-						if ($event instanceof Event) {
-							$day = intval(Carbon::createFromTimestamp($timestamp, $calendar->timezone)->endOfDay()->day);
-							$day_events[$day][] = $event;
-						}
-					}
-				}
+			foreach ($day_events as $day_key => $events) {
+				$day_events[$day_key] = array_values($events);
 			}
 
 			ksort($day_events, SORT_NUMERIC);

--- a/includes/calendars/views/default-calendar-grid.php
+++ b/includes/calendars/views/default-calendar-grid.php
@@ -373,34 +373,45 @@ class Default_Calendar_Grid implements Calendar_View
 					: [];
 
 			$day_events = [];
-			foreach ($filtered as $timestamp => $events_in_day) {
-				foreach ($events_in_day as $event) {
-					if ($event instanceof Event) {
-						$event_start = Carbon::createFromTimestamp($event->start, $calendar->timezone);
-						$event_end = Carbon::createFromTimestamp($event->end, $calendar->timezone);
+			if ('yes' == get_post_meta($calendar->id, '_default_calendar_expand_multi_day_events', true)) {
+				foreach ($filtered as $timestamp => $events_in_day) {
+					foreach ($events_in_day as $event) {
+						if ($event instanceof Event) {
+							$event_start = Carbon::createFromTimestamp($event->start, $calendar->timezone);
+							$event_end = Carbon::createFromTimestamp($event->end, $calendar->timezone);
 
-						for ($day = $event_start->copy(); $day->lte($event_end->endOfDay()); $day->addDay()) {
-							if ($day->month == $current_month && $day->year == $current_year) {
-								$day_key = intval($day->format('j'));
-								$event_id = $event->uid;
-								/*
-								 * The purpose of this condition is to determine if an event ends at the very start of the day.
-								 */
-								if ($day->isSameDay($event_end) && $event_end->hour == 0 && $event_end->minute == 0) {
-									continue;
-								}
+							for ($day = $event_start->copy(); $day->lte($event_end->endOfDay()); $day->addDay()) {
+								if ($day->month == $current_month && $day->year == $current_year) {
+									$day_key = intval($day->format('j'));
+									$event_id = $event->uid;
+									/*
+									 * The purpose of this condition is to determine if an event ends at the very start of the day.
+									 */
+									if ($day->isSameDay($event_end) && $event_end->hour == 0 && $event_end->minute == 0) {
+										continue;
+									}
 
-								if (!isset($day_events[$day_key][$event_id])) {
-									$day_events[$day_key][$event_id] = $event;
+									if (!isset($day_events[$day_key][$event_id])) {
+										$day_events[$day_key][$event_id] = $event;
+									}
 								}
 							}
 						}
 					}
 				}
-			}
 
-			foreach ($day_events as $day_key => $events) {
-				$day_events[$day_key] = array_values($events);
+				foreach ($day_events as $day_key => $events) {
+					$day_events[$day_key] = array_values($events);
+				}
+			} else {
+				foreach ($filtered as $timestamp => $events_in_day) {
+					foreach ($events_in_day as $event) {
+						if ($event instanceof Event) {
+							$day = intval(Carbon::createFromTimestamp($timestamp, $calendar->timezone)->endOfDay()->day);
+							$day_events[$day][] = $event;
+						}
+					}
+				}
 			}
 
 			ksort($day_events, SORT_NUMERIC);


### PR DESCRIPTION
**Description:** Multiday events tend to show up on all days even if they are only set to display on the first date of the month, is fixed now.
**ClickUp:**https://app.clickup.com/t/86cxyg7qr
**Before & After:** https://drive.google.com/file/d/1D-dI25EKvQ5GBzK1VIrcli1FkTmNTwQ9/view?usp=drivesdk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to expand multi-day events across all days they span in the calendar view, controlled by a calendar setting.

- **Bug Fixes**
  - Ensured multi-day events are not duplicated within the same day and are displayed accurately based on the calendar setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->