### PR TITLE
Network issue on oauth via SC

### DIFF
--- a/includes/feeds/google.php
+++ b/includes/feeds/google.php
@@ -556,7 +556,6 @@ class Google extends Feed
 				$args['orderBy'] = 'startTime';
 			}
 
-			$is_authhelper = get_option('simple_calendar_run_oauth_helper');
 			$feed_type = wp_get_object_terms($this->post_id, 'calendar_feed');
 
 			// Query events in calendar.
@@ -565,7 +564,7 @@ class Google extends Feed
 			$backgroundcolor = '';
 			if (
 				isset($simple_calendar_auth_site_token) &&
-				!empty($simple_calendar_auth_site_token && $is_authhelper) &&
+				!empty($simple_calendar_auth_site_token) &&
 				isset($feed_type[0]->slug) &&
 				$feed_type[0]->slug != 'google'
 			) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.5.4",
+  "version": "3.5.5",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,10 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.5.5 =
+* Fix: Network error when fetching calendars after authentication with Oauth via Simple Calendar on fresh installs.
+* Fix: JS issue preventing custom CSS from applying to qTip tooltips in version 3.5.4.
+
 = 3.5.4 =
 * Fix: Fixed multi-day events incorrectly displaying on all days when the "No, display only on first day of event" option is enabled.
 * Fix: Resolved issue where event details (qTip) were not showing in mobile portrait view.


### PR DESCRIPTION
**Description:** There were network issue and a front-end event display issue on fresh install with Oauth via SC.
**Clickup:** https://app.clickup.com/t/86czea063
**After:** https://drive.google.com/file/d/1nALaIBM628wCJ42BczPVRagAPaAp6S1-/view?usp=drivesdk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a network error when fetching calendars after OAuth authentication on fresh installs.
  * Fixed an issue where custom CSS was not applied to qTip tooltips.

* **Documentation**
  * Updated the changelog to reflect the latest fixes.

* **Chores**
  * Bumped the version number to 3.5.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->