### PR TITLE
Load js and css only on calendar post and page

### DIFF
--- a/includes/assets.php
+++ b/includes/assets.php
@@ -74,31 +74,59 @@ class Assets
 
 	/**
 	 * Enqueue scripts and styles.
-	 *
+	 * Add action to check post type and shortcode when post is available
 	 * @since 3.0.0
 	 */
 	public function enqueue()
 	{
-		add_action('wp_enqueue_scripts', [$this, 'load'], 10);
+		add_action('wp', [$this, 'check_load_assets']);
+	}
 
-		do_action('simcal_enqueue_assets');
+	/**
+	 * Check if we should load assets.
+	 *
+	 * @since 3.5.6
+	 */
+	public function check_load_assets()
+	{
+		// Only load assets if it's a calendar post type or if we detect calendar shortcode
+		$load_assets = false;
 
-		// Improves compatibility with themes and plugins using Isotope and Masonry.
-		add_action(
-			'wp_enqueue_scripts',
-			function () {
-				if (wp_script_is('simcal-qtip', 'enqueued')) {
-					wp_enqueue_script(
-						'simplecalendar-imagesloaded',
-						SIMPLE_CALENDAR_ASSETS . 'generated/vendor/imagesloaded.pkgd.min.js',
-						['simcal-qtip'],
-						SIMPLE_CALENDAR_VERSION,
-						true
-					);
+		if (is_singular('calendar')) {
+			$load_assets = true;
+		}
+
+		if (is_front_page() || is_home() || is_singular()) {
+			global $post;
+			if (isset($post)) {
+				if (has_shortcode($post->post_content, 'calendar')) {
+					$load_assets = true;
 				}
-			},
-			1000
-		);
+			}
+		}
+
+		if ($load_assets) {
+			add_action('wp_enqueue_scripts', [$this, 'load'], 10);
+
+			do_action('simcal_enqueue_assets');
+
+			// Improves compatibility with themes and plugins using Isotope and Masonry.
+			add_action(
+				'wp_enqueue_scripts',
+				function () {
+					if (wp_script_is('simcal-qtip', 'enqueued')) {
+						wp_enqueue_script(
+							'simplecalendar-imagesloaded',
+							SIMPLE_CALENDAR_ASSETS . 'generated/vendor/imagesloaded.pkgd.min.js',
+							['simcal-qtip'],
+							SIMPLE_CALENDAR_VERSION,
+							true
+						);
+					}
+				},
+				1000
+			);
+		}
 	}
 
 	/**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "google-calendar-events",
   "title": "Simple Calendar",
   "description": "Add Google Calendar events to your WordPress site.",
-  "version": "3.5.5",
+  "version": "3.5.6",
   "license": "GPLv2+",
   "homepage": "https://simplecalendar.io",
   "repository": {

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,9 @@ We'd love your help! Here's a few things you can do:
 
 == Changelog ==
 
+= 3.5.6 =
+* Dev: Load CSS and JS only on calendar posts and pages containing the calendar shortcode for better performance.
+
 = 3.5.5 =
 * Fix: Network error when fetching calendars after authentication with Oauth via Simple Calendar on fresh installs.
 * Fix: JS issue preventing custom CSS from applying to qTip tooltips in version 3.5.4.


### PR DESCRIPTION
**Description:** Improve the CSS and JS loading in Simple Calendar so that the files are only loaded on pages where the calendar is added.

**Clickp:** https://app.clickup.com/t/86cy3tne5
**After:** https://drive.google.com/file/d/1ASkx579IeW6EX6GfYtluBWS1WRbMYRG-/view?usp=drivesdk