### PR TITLE
Add notice to stop support for PHP7

### DIFF
--- a/includes/functions/admin.php
+++ b/includes/functions/admin.php
@@ -463,5 +463,27 @@ function simcal_notice_to_update_php_version()
 		unset($notices[$notice_id]);
 		update_option('simple-calendar_admin_notices', $notices);
 	}
+	/*
+	 * Notice for not providing support for PHP
+	 * This need to be remove afte 1st november 2025
+	 */
+	$update_pro_notice = new Notice([
+		'id' => [
+			$notice_id => 'discontinuing_support_for_php7',
+		],
+		'type' => 'error',
+		'dismissable' => true,
+		'content' =>
+			'<p>' .
+			'<i class="simcal-icon-calendar-logo"></i> ' .
+			__(
+				'<strong>Attention!</strong></br> On <strong>November 01 2025</strong>, , we will be updating our plugin to the latest Google libraries and discontinuing support for PHP 7.x. 
+					To ensure your calendar plugin continues to work without interruption, please upgrade your PHP version to 8.0 or higher. If you\'ve already upgraded, you\'re all set!',
+				'google-calendar-events'
+			) .
+			'</p>',
+	]);
+
+	$update_pro_notice->add();
 }
 add_action('admin_init', 'simcal_notice_to_update_php_version');


### PR DESCRIPTION
**Description:** We have added and notice for php7 support, it is visible to all users as this is to inform to all the user that we will stop support for php7.

**Clickup:** https://app.clickup.com/t/86d0d4k85

**Before & After:** https://www.awesomescreenshot.com/video/44484362?key=e9d1d9a906078cb82c09f286af0c7f28